### PR TITLE
use namedtuple for measurement_value

### DIFF
--- a/adafruit_ble_heart_rate.py
+++ b/adafruit_ble_heart_rate.py
@@ -41,9 +41,9 @@ Implementation Notes
 * Adafruit's BLE library: https://github.com/adafruit/Adafruit_CircuitPython_BLE
 """
 import struct
-import _bleio
 from collections import namedtuple
 
+import _bleio
 from adafruit_ble.services import Service
 from adafruit_ble.uuid import StandardUUID
 from adafruit_ble.characteristics import Characteristic, ComplexCharacteristic

--- a/adafruit_ble_heart_rate.py
+++ b/adafruit_ble_heart_rate.py
@@ -52,25 +52,25 @@ from adafruit_ble.characteristics.int import Uint8Characteristic
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE_Heart_Rate.git"
 
-HeartRateMeasurementValue = namedtuple(
-    "HeartRateMeasurementValue",
+HeartRateMeasurementValues = namedtuple(
+    "HeartRateMeasurementValues",
     ("heart_rate", "contact", "energy_expended", "rr_intervals"))
-"""Namedtuple for the parts of a measurement value.
+"""Namedtuple for measurement values.
 
-.. py:attribute:: HeartRateMeasurementValue.heart_rate
+.. py:attribute:: HeartRateMeasurementValues.heart_rate
 
         Heart rate (int), in beats per minute.
 
-.. py:attribute:: HeartRateMeasurementValue.contact
+.. py:attribute:: HeartRateMeasurementValues.contact
 
         ``True`` if device is contacting the body, ``False`` if not,
         ``None`` if device does not support contact detection.
 
-.. py:attribute:: HeartRateMeasurementValue.energy_expended
+.. py:attribute:: HeartRateMeasurementValues.energy_expended
 
         Energy expended (int), in kilo joules, or ``None`` if no value.
 
-.. py:attribute:: HeartRateMeasurementValue.rr_intervals
+.. py:attribute:: HeartRateMeasurementValues.rr_intervals
 
         Sequence of RR intervals, measuring the time between
         beats. Oldest first, in ints that are units of 1024ths of a second.
@@ -80,7 +80,7 @@ HeartRateMeasurementValue = namedtuple(
 
 For example::
 
-    bpm = svc.measurement_value.heart_rate
+    bpm = svc.measurement_values.heart_rate
 """
 
 class _HeartRateMeasurement(ComplexCharacteristic):
@@ -141,7 +141,7 @@ class HeartRateService(Service):
 
     @property
     def measurement_values(self):
-        """All the measurement values, returned as a HeartRateMeasurementValue
+        """All the measurement values, returned as a HeartRateMeasurementValues
         namedtuple.
 
         Return ``None`` if no packet has been read yet.
@@ -179,7 +179,7 @@ class HeartRateService(Service):
                 rr_val = struct.unpack_from("<H", buf, offset)[0]
                 rr_values.append(rr_val)
 
-        return HeartRateMeasurementValue(bpm, contact, energy_expended, rr_values)
+        return HeartRateMeasurementValues(bpm, contact, energy_expended, rr_values)
 
     @property
     def location(self):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,2 @@
-
-.. If you created a package, create one automodule per module in the package.
-
-.. If your library file(s) are nested in a directory (e.g. /adafruit_foo/foo.py)
-.. use this format as the module name: "adafruit_foo.foo"
-
 .. automodule:: adafruit_ble_heart_rate
    :members:


### PR DESCRIPTION
Printing `HeartRateService.measurement_valuse` now looks like:
```python3
HeartRateMeasurementValues(heart_rate=60, contact=None, energy_expended=None, rr_intervals=[1024])
HeartRateMeasurementValues(heart_rate=58, contact=None, energy_expended=None, rr_intervals=[1059])
```
and you can now do things like:
```python3
print(svc.measurement_values.heart_rate)  # print heart rate
```
instead of 
```python3
print(svc.measurement_values[0])  # print heart rate
```

Also I fixed some sphinx documentation bugs.

(EDIT: Fixed measurement values names to be plural)
