### PR TITLE
update example to use .packet_size

### DIFF
--- a/adafruit_ble_heart_rate.py
+++ b/adafruit_ble_heart_rate.py
@@ -134,10 +134,7 @@ class HeartRateService(Service):
 
     def __init__(self, service=None):
         super().__init__(service=service)
-#### TODO Use commented line instead once .packet_size is fixed in CircuitPython beta.
-####    self._measurement_buf = bytearray(self.heart_rate_measurement.packet_size)
-#### TEMPORARY
-        self._measurement_buf = bytearray(20)
+        self._measurement_buf = bytearray(self.heart_rate_measurement.packet_size)
 
     @property
     def measurement_values(self):


### PR DESCRIPTION
Remove workaround for bad `.packet_size` that is fixed in CircuitPython 5.0.0-beta.5

@dherrada @dglaude Note this fix.